### PR TITLE
Corrected Punjabi Shahmukhi entry

### DIFF
--- a/langs.js
+++ b/langs.js
@@ -1694,7 +1694,7 @@ related:`Macrolanguage is Malagasy [mg]. Legacy applications often use mg rather
 "pnb": { name:"Punjabi", local: "پنجابی ‎[paṁjābī]", rtl:true, source:"f940e5c7fc381992f942120f89cd8137cb3c3eda,cldr_pnb,udhr_pnb", region:"sasia", countries:"Pakistan, India", script:"arab", speakers:"125000000", letter:"آابپتٹجچخدذڈرزڑسشفکگلمنںہھوؤیئےۓ", letteraux: "ۃݨࣇءثحژصضطظعغق", mark:"\u064F\u0650\u064E\u0651", markaux: "\u064B\u0656\u0670\u0658\u0614\u0658", other: "\u200C", number:"۰۱۲۳۴۵۶۷۸۹", punctuation:"،؍؛؟٪٫٫٬٬۔“”", deprecated: "ٔٓهيكڻة", 
 orth:`Shahmukhi. &nbsp; Urdu orthography for Punjabi primarily in the Nastaliq style, primarily used in Pakistan contemporarily.`,
 also:
-['pa | guru | Primary usage for Gurmukhi.
+['pa | guru | Primary usage for Gurmukhi.',
 'pnb-khoj | khoj | Historical script used by Khoja and Sindhi communities, moreso for Sindhi than Punjabi.',
 'pnb-latn | latn | There is no standard Latin script based orthography for Punjabi.'],
 notes: `Same as [a]. [pa] is typically used for Gurmukhi and [pnb] is typically used for Shahmukhi. pa-arab is rarely used. Some providers use pa_PK.`

--- a/langs.js
+++ b/langs.js
@@ -1639,26 +1639,19 @@ linked:"osage", fonts:"/pickers/osge/",
 
 "ote": { name:"Mezquital Otomi", source:"udhr_ote", region:"cam", countries:"Mexico", script:"latn", speakers:"130000", letter:"öüäéñúíáèÖÜÄÉÑÚÍÁÈ", mark:"̱̈́̃̀", local:"Hñahñu"},
 
-"pa": { name:"Punjabi", local:"ਪੰਜਾਬੀ‎ (Panjabi), ਪੰਜਾਬੀ ਭਾਸ਼ਾ‎ (Panjabi bhasa)", silcode:"pan", 
-source:"cldr_pa,udhr_pan,f940e5c7fc381992f942120f89cd8137cb3c3eda", 
-region:"sasia", countries:"India", script:"guru", speakers:"122000000", 
+"pa": { name:"Punjabi", local:"ਪੰਜਾਬੀ [paṁjābī]", 
+source:"f940e5c7fc381992f942120f89cd8137cb3c3eda,cldr_pa,udhr_pan", 
+region:"sasia", countries:"India,Pakistan", script:"guru", speakers:"125000000", 
 letter:"ਅਆਇਈਉਊਏਐਓਔਕਖਗਘਙਚਛਜਝਞਟਠਡਢਣਤਥਦਧਨਪਫਬਭਮਯਰਲਵਸਹੜੴ", mark:"ੱੰ਼੍ਾਿੀੁੂੇੈੋੌਂ", number:"੦੧੨੩੪੫੬੭੮੯", punctuation:"‐–—‘’“”′″।", symbol:"☬", other:"\u200C\u200D", markaux:"ਃਁੵ", letteraux:"\u0A5E\u0A5B\u0A36\u0A59\u0A5A\u0A33", deprecated:"ੳੲ", 
-orth:`Gurmukhi. &nbsp; Primary usage. <a href="../scripts/gurmukhi" target="_blank">Details</a>.`,
+orth:`Gurmukhi. &nbsp; Brahmic script primarily used in India contemporarily and in Sikh literature. <a href="../scripts/gurmukhi" target="_blank">Details</a>.`,
 also:
-["pa-arab | arab | Naskh style. See also [pnb].",
-"pa-khoj | khoj | "],
-notes:`Need to check the difference between pa-arab and pnb.`,
+["pnb | arab | Primary usage for Shahmukhi.",
+"pa-arab | arab | Same as [pnb].",
+"pa-khoj | khoj | Historical script used by Khoja and Sindhi communities, moreso for Sindhi than Punjabi."],
+notes:`Same as [pnb]. [pa] is typically used for Gurmukhi and [pnb] is typically used for Shahmukhi. pa-arab is rarely used.`,
 type:"abugida", cs:"no", gpos:"yes", gsub:"yes", cursive:"no", direction:"ltr", wordsep:"space", baseline:"high", wrap:"word", hyphenation:"?",  justification:"sp",
 vowels:"inh:1 ind:10 vs:9 pre:1", clusters:"inv stk rax unm", finals:"cm:1", 
 linked:"gurmukhi", fonts:"/pickers/guru/", 
-},
-
-"pa-arab": { name:"Punjabi", silcode:"pan", rtl:true, source:"cldr_pa_Arab", region:"sasia", script:"arab", speakers:"122000000", letter:"ءآؤئابتثجحخدذرزسشصضطظعغفقلمنهويٹپچڈڑژکگںھہیے", mark:"ُٓٔ", punctuation:"‰", other:"‎‏", aux:"أاةٔٺٻټٽ", 
-orth:`Arabic. &nbsp; Naskh style. See also [pnb].`,
-also:
-['pa | guru | Primary usage.',
-'pa-khoj | khoj | '],
-notes:`Need to check the difference between pa-arab and pnb.`
 },
 
 "pam": { name:"Pampangan (Kapampangan)", source:"udhr_pam", region:"seasia", countries:"Philippines", script:"ascii", speakers:"1900000", local:"Kapampangan"},
@@ -1698,12 +1691,13 @@ linked:"arabic/arab-fa", fonts:"/pickers/arab-fa/",
 "plt": { name:"Plateau Malagasy", source:"cldr_mg,udhr_plt", region:"afr", countries:"Madagascar", script:"latn", speakers:"18000000", letter:"àâéèêëìîïñôÀÂÉÈÊËÌÎÏÑÔ", mark:"̀̂́̈̃", local:"Malagasy", notes:"UDHR has no accents", 
 related:`Macrolanguage is Malagasy [mg]. Legacy applications often use mg rather plt.`},
 
-"pnb": { name:"Western Panjabi", rtl:true, source:"cldr_pnb,udhr_pnb", region:"sasia", countries:"Pakistan, India", script:"arab", speakers:"122000000", letter:"ءآؤئابپتثٹجچحخدذڈرزڑژسشصضطظعغفقکگلمنںهھہویےي", mark:"ُٓٔ", punctuation:"‐–—‘’“”′″", local:"پنجابی‎ (Panjābī)", notes:`Need to ascertain whether this is the same as [pa-arab].`, 
-orth:`Arabic. &nbsp; Naskh and nastaliq ([Aran]) styles in primary usage.
-Also used Lahnda script, but no longer in use (and no ISO script tag.)`,
+"pnb": { name:"Punjabi", local: "پنجابی ‎[paṁjābī]", rtl:true, source:"f940e5c7fc381992f942120f89cd8137cb3c3eda,cldr_pnb,udhr_pnb", region:"sasia", countries:"Pakistan, India", script:"arab", speakers:"125000000", letter:"آابپتٹجچخدذڈرزڑسشفکگلمنںہھوؤیئےۓ", letteraux: "ۃݨࣇءثحژصضطظعغق", mark:"\u064F\u0650\u064E\u0651", markaux: "\u064B\u0656\u0670\u0658\u0614\u0658", other: "\u200C", number:"۰۱۲۳۴۵۶۷۸۹", punctuation:"،؍؛؟٪٫٫٬٬۔“”", deprecated: "ٔٓهيكڻة", 
+orth:`Shahmukhi. &nbsp; Urdu orthography for Punjabi primarily in the Nastaliq style, primarily used in Pakistan contemporarily.`,
 also:
-['pnb-khoj | khoj | ',
-'pnb-latn | latn | ']
+['pa | guru | Primary usage for Gurmukhi.
+'pnb-khoj | khoj | Historical script used by Khoja and Sindhi communities, moreso for Sindhi than Punjabi.',
+'pnb-latn | latn | There is no standard Latin script based orthography for Punjabi.'],
+notes: `Same as [a]. [pa] is typically used for Gurmukhi and [pnb] is typically used for Shahmukhi. pa-arab is rarely used. Some providers use pa_PK.`
 },
 
 "pon": { name:"Pohnpeian (Ponapean)", source:"udhr_pon", region:"oce", countries:"Micronesia", script:"ascii", speakers:"31000", local:"Pohnpei"},


### PR DESCRIPTION
I noticed on your site you have a notes on `pa`, `pa-arab`, and `pnb` about checking if these are the same. They are in fact the same. `pa` is typically used for the Gurmukhi script, and `pnb` is typically used for the Shahmukhi script, which is an adaptation of Urdu Perso-Arabic orthography for Punjabi. For some incoherent reason ISO/SIL have always maintained two duplicate codes for the language. There is no real linguistic distinction that they can be understood to represent. The majority of Punjabi speakers can only read Shahmukhi, but Gurmukhi has been set as the "default" script for `pa` by most providers at this point, so as a result `pnb` is de facto used as the code for Shahmukhi and `pa` for Gurmukhi.

I corrected the alphabet and characters included in the `pnb`  entry, and removed the `pa-arab` entry since it is less frequently used and would create a duplicate on the website (`pa-arab` also had more errors in the character list). I updated the speaker count (see https://www.tribuneindia.com/news/punjab/12-5-crore-people-are-speaking-punjabi-worldwide-today-220786), and also added a more precise transcription for the autonym of the language.

"Western Punjabi" and "Eastern Punjabi" are confusing labels which should be avoided for distinctions that have to do with script, not dialect. I am of a Pakistani background and am primarily familiar with what are considered eastern dialects, Doabi and Majhi, and most people I know are only familiar with the Arabic-based script. Likewise, because Sikhism originated in western Punjab, there are words which are primarily printed in Gurmukhi literature like ਵੰਞਣ which are actually indicative of western Punjabi dialects despite Gurmukhi being used more in eastern Punjab today. Dialect has been too fluid for historical reasons to allow it to be easily discerned between speakers/writers. The distinctions which do exist in dialect do not fall along the India/Pakistan boundary as this was too recently created to have influenced spoken language. Many Pakistanis were born on the Indian side of the border and vice versa. Only the script can be said to be different between the two countries. I removed the `silcode` field because the links those codes would go to are misleading in this regard.

I noticed there are problems with the Urdu entry, and with the Urdu script notes as well that I would like to make PRs for when I have some time. I could also help provide information for documenting the details of Shahmukhi in the way you have done for Gurmukhi if you are interested. Let me know if you have any questions