### PR TITLE
Fix Slovak (sk) alphabet

### DIFF
--- a/langs.js
+++ b/langs.js
@@ -2191,7 +2191,7 @@ linked:"sinh/si", picker:"sinh",
 
 "sja": { name:"Epena (Eperara)", source:"udhr_sja", region:"sam", countries:"Colombia", script:"ascii", speakers:"8300", local:"Epéna Pedée"},
 
-"sk": { name:"Slovak", silcode:"slk", source:"cldr_sk,udhr_slk", region:"eur", countries:"Slovakia, Czechia, Serbia", script:"latn", speakers:"5200000", letter:"čďĺľňŕšťžűČĎĹĽŇŔŠŤŽŰáäéíóôúýÁÄÉÍÓÔÚÝ", mark:"́̈̌̂̋", punctuation:"‐–…‘‚“„§", aux:"ăāĕēĭīŏōœřŭūĂĀĔĒĬĪŎŌŒŘŬŪŸàâåæçèêëìîïñòöøùûüÿÀÂÅÆÇÈÊËÌÎÏÑÒÖØÙÛǛ̧̆̊̄̃", local:"Slovenský Jazyk / Slovenčina"},
+"sk": { name:"Slovak", silcode:"slk", source:"cldr_sk,udhr_slk", region:"eur", countries:"Slovakia, Czechia, Serbia", script:"latn", speakers:"5200000", letter:"áÁäÄčČďĎéÉíÍĺĹľĽňŇóÓôÔŕŔšŠťŤúÚýÝžŽ", mark:"́̂̌̈", punctuation:"‐–…‘‚“„§", aux:"ăāĕēĭīŏōœřŭūĂĀĔĒĬĪŎŌŒŘŬŪŸàâåæçèêëìîïñòöøùûüÿÀÂÅÆÇÈÊËÌÎÏÑÒÖØÙÛǛ̧̆̊̄̃", local:"Slovenský Jazyk / Slovenčina"},
 
 "skr": { name:"Saraiki (Siraiki, Seraiki)", local:"سرائیکی‎", localtrans:"sə.ˈɾɛːkiː", silcode:"skr", rtl:true, 
 source:"r12a, udhr_skr", 


### PR DESCRIPTION
For some reason, the Slovak alphabet contains extra letters - „ű“ and „Ű“ - that are not used in the Slovak language.

This put puts the alphabet in line with CLDR (https://www.unicode.org/cldr/charts/46/summary/sk.html).